### PR TITLE
Add atom for Headings

### DIFF
--- a/src/components/atoms/heading/Heading.stories.ts
+++ b/src/components/atoms/heading/Heading.stories.ts
@@ -1,0 +1,16 @@
+import type { Story } from '@muban/storybook/dist/client/preview/types-6-0';
+import { meta, HeadingTemplateProps } from './Heading.template';
+
+export default {
+  title: 'Button',
+  argTypes: {
+    label: { control: 'text' },
+  },
+};
+
+export const Default: Story<HeadingTemplateProps> = () => meta;
+Default.args = {
+  as: 'h1',
+  style: 'h2',
+  copy: 'Hello World',
+};

--- a/src/components/atoms/heading/Heading.template.ts
+++ b/src/components/atoms/heading/Heading.template.ts
@@ -1,0 +1,12 @@
+import { html, unsafeHTML } from '@muban/muban';
+
+type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export type HeadingTemplateProps = {
+  as: Heading;
+  style: Heading;
+  copy: string;
+};
+
+export const headingTemplate = ({ as, style, copy }: HeadingTemplateProps): string =>
+  html`<${as} class="${style}"  data-component="heading=">${unsafeHTML(copy)}</${as}>`;

--- a/src/components/atoms/heading/Heading.template.ts
+++ b/src/components/atoms/heading/Heading.template.ts
@@ -9,4 +9,8 @@ export type HeadingTemplateProps = {
 };
 
 export const headingTemplate = ({ as, style, copy }: HeadingTemplateProps): string =>
-  html`<${as} class="${style}"  data-component="heading=">${unsafeHTML(copy)}</${as}>`;
+  html`<${as} class="${style}" data-component="heading=">${unsafeHTML(copy)}</${as}>`;
+
+export const meta = {
+  template: headingTemplate,
+};

--- a/src/components/atoms/heading/heading.scss
+++ b/src/components/atoms/heading/heading.scss
@@ -1,8 +1,25 @@
 [data-component="heading"] {
-  &.h1 {}
-  &.h2 {}
-  &.h3 {}
-  &.h4 {}
-  &.h5 {}
-  &.h6 {}
+  &.h1 {
+    @include heading-01;
+  }
+
+  &.h2 {
+    @include heading-02;
+  }
+
+  &.h3 {
+    @include heading-03;
+  }
+
+  &.h4 {
+    @include heading-04;
+  }
+
+  &.h5 {
+    @include heading-05;
+  }
+
+  &.h6 {
+    @include heading-06;
+  }
 }

--- a/src/components/atoms/heading/heading.scss
+++ b/src/components/atoms/heading/heading.scss
@@ -1,0 +1,8 @@
+[data-component="heading"] {
+  &.h1 {}
+  &.h2 {}
+  &.h3 {}
+  &.h4 {}
+  &.h5 {}
+  &.h6 {}
+}

--- a/src/styles/layout/_base.scss
+++ b/src/styles/layout/_base.scss
@@ -12,6 +12,16 @@ body {
   margin: 0;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: normal;
+  margin: 0;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -23,7 +33,7 @@ a {
   box-sizing: inherit;
 }
 
-ul,
+h1 ul,
 ol {
   margin: 0;
   list-style: none;

--- a/src/styles/type/_typography.scss
+++ b/src/styles/type/_typography.scss
@@ -1,9 +1,5 @@
 /* Stylesheet for all generic typography styles */
 
-h1, h2, h3, h4, h5, h6 {
-  margin: 0;
-}
-
 // Body copy
 .copy-01 {
   @include copy-01;

--- a/src/styles/type/_typography.scss
+++ b/src/styles/type/_typography.scss
@@ -16,28 +16,3 @@
 .copy-04 {
   @include copy-04;
 }
-
-// Heading
-.heading-01 {
-  @include heading-01;
-}
-
-.heading-02 {
-  @include heading-02;
-}
-
-.heading-03 {
-  @include heading-03;
-}
-
-.heading-04 {
-  @include heading-04;
-}
-
-.heading-05 {
-  @include heading-05;
-}
-
-.heading-06 {
-  @include heading-06;
-}


### PR DESCRIPTION
The heading component can be used to create `h1`-`h6` components that can be styled independent for its element. This allows for `h2` components with the look of an `h1`. The component uses the styles set in the mixins folder. It's a first draft and classnames and such can (and perhaps should) be adjusted or changed. `${heading({ as='h3', style='h1' copy='Hello <strong>world</stong>' });` will result in: `<h3 class="h1" data-component="heading=">Hello <strong>world</strong></h3>`