### PR TITLE
remove require calls from postcss plugins

### DIFF
--- a/config/webpack.config.ts
+++ b/config/webpack.config.ts
@@ -173,9 +173,9 @@ module.exports = function () {
                   options: {
                     postcssOptions: {
                       plugins: [
-                        require('postcss-flexbugs-fixes'),
+                        'postcss-flexbugs-fixes',
                         [
-                          require('postcss-preset-env'),
+                          'postcss-preset-env',
                           {
                             autoprefixer: {
                               flexbox: 'no-2009',


### PR DESCRIPTION
@pigeonfresh noticed that his defined CSS's logical properties were being removed in the bundled CSS.

After some quick initial investigation, we discovered that setting `browserlist` to Chrome 90 seemed to make the properties show up. Diving deeper I noticed that changing anything within the `postcss-preset-env` options had no affect.

So it turns out that if you pass a plugin as a function, instead of a string, then any options you pass will be ignored.
[postcss-loader/src/utils.js#L198](https://github.com/webpack-contrib/postcss-loader/blob/master/src/utils.js#L198)

```js
postcssOptions: {
  plugins: [
    ...,
    [
      require('postcss-preset-env'), // the options object will be ignored :(
      { ... }
    ],
    [
      'postcss-preset-env', // the options object will be used! :)
      { ... }
    ],
  ],
},

```
This led to our options being completely ignored and the odd defaults of each of the plugins somehow decided to remove the logical properties. The only change this PR makes is removing the `require` (importing) calls of the postcss plugin and instead passing their string identifiers.