### PR TITLE
Add abiltity to run muban-skeleton under a hash based strict CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ The dev server runs on `http://localhost:9001`.
 
 > TODO
 
+### Content Security Policy ([CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP))
+
+This application has been build with a [strict content security policy](https://csp.withgoogle.com/docs/strict-csp.html). To enforce this policy 
+add the following CSP header to the request response.
+
+`Content-Security-Policy: script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';`
+

--- a/scripts/devserver/index.html
+++ b/scripts/devserver/index.html
@@ -6,6 +6,9 @@
 
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
+  <meta name="app-script" content="{{publicPath}}/static/js/main.js" />
+
+  {{csp}}
 
   <link rel="stylesheet" href="{{publicPath}}/static/css/main.css"/>
 </head>
@@ -14,6 +17,6 @@
     {{content}}
   </div>
 
-  <script src="{{publicPath}}/static/js/main.js"></script>
+  <script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
 </body>
 </html>

--- a/scripts/devserver/webpackDevServer.config.ts
+++ b/scripts/devserver/webpackDevServer.config.ts
@@ -153,6 +153,9 @@ export function createDevServerConfig(proxy, allowedHost) {
           replaceTemplateVars(
             readFileSync(path.resolve(__dirname, './index.html'), 'utf-8'),
             templateResult,
+            {
+              csp: `<meta http-equiv="Content-Security-Policy" content="script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';">`,
+            },
           ),
         );
       });

--- a/scripts/generateTemplates.ts
+++ b/scripts/generateTemplates.ts
@@ -105,7 +105,9 @@ async function start() {
       const data = await getPageData(page.id);
       const templateResult = await getAppTemplate(data);
 
-      const pageOutput = replaceTemplateVars(pageTemplate, templateResult || '');
+      const pageOutput = replaceTemplateVars(pageTemplate, templateResult || '', {
+        csp: '',
+      });
 
       const outputPath = path.resolve(paths.distSitePath, `${page.id}.html`);
       fs.ensureFileSync(outputPath);


### PR DESCRIPTION
These changes allow Muban Skeleton to run under a [strict Content Security Policy](https://csp.withgoogle.com/docs/strict-csp.html). 

The strict CSP will be applied in development mode, which should prevent "surprises" on build time. However strict CSP isn't automatically enabled whenever running a build, so it's an opt-in solution. The CSP header as listed in the <meta http-equiv="Content-Security-Policy" ... /> should be added to server response as well.