### PR TITLE
Upgrade muban to `muban@1.0.0-alpha.28`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.17",
-    "@muban/muban": "^1.0.0-alpha.27",
+    "@muban/muban": "1.0.0-alpha.28",
     "@muban/storybook": "^7.0.0-alpha.14",
     "@muban/template": "^1.0.0-alpha.1",
     "classnames": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,17 +2183,17 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@muban/muban@^1.0.0-alpha.27":
-  version "1.0.0-alpha.27"
-  resolved "https://registry.yarnpkg.com/@muban/muban/-/muban-1.0.0-alpha.27.tgz#23255cd131ee1c8468d2d241abebded69659c924"
-  integrity sha512-e5p4/+3GaGX96JKMKelw1kBPUwDTf0AqNo/5uV6mAoFXEteBwVZXSPKHtCMTKv0ifk7q/541VpegOBD1q0tiXg==
+"@muban/muban@1.0.0-alpha.28":
+  version "1.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@muban/muban/-/muban-1.0.0-alpha.28.tgz#54e1d335130b650bc40896b328b999a5e1673dfb"
+  integrity sha512-8Tpb4tKiTiyhTvoXycXbdrebXVRrvSz/KZZDzqw5ryHGpm9Klvvma6E0dfRfP+6gPn4eKvaUgE88gwxKfsSv8Q==
   dependencies:
     "@types/json-parse-better-errors" "^1.0.0"
     "@types/lodash-es" "^4.17.3"
     "@types/webpack" "^4.41.25"
     "@types/webpack-env" "^1.15.2"
-    "@vue/reactivity" "^3.0.2"
-    "@vue/runtime-core" "^3.0.2"
+    "@vue/reactivity" "^3.2.22"
+    "@vue/runtime-core" "^3.2.22"
     bootstrap-icons "^1.1.0"
     htm "^3.0.4"
     html-extract-data "^1.0.1"
@@ -3312,25 +3312,25 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/reactivity@3.0.2", "@vue/reactivity@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.2.tgz#42ed5af6025b494a5e69b05169fcddf04eebfe77"
-  integrity sha512-GdRloNcBar4yqWGXOcba1t//j/WizwfthfPUYkjcIPHjYnA/vTEQYp0C9+ZjPdinv1WRK1BSMeN/xj31kQES4A==
+"@vue/reactivity@3.2.26", "@vue/reactivity@^3.2.22":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.26.tgz#d529191e581521c3c12e29ef986d4c8a933a0f83"
+  integrity sha512-h38bxCZLW6oFJVDlCcAiUKFnXI8xP8d+eO0pcDxx+7dQfSPje2AO6M9S9QO6MrxQB7fGP0DH0dYQ8ksf6hrXKQ==
   dependencies:
-    "@vue/shared" "3.0.2"
+    "@vue/shared" "3.2.26"
 
-"@vue/runtime-core@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.2.tgz#d7ed462af1cb0bf9836668e4e6fab3f2f4b1bc00"
-  integrity sha512-3m/jOs2xSipEFah9FgpEzvC9nERFonVGLN06+pf8iYPIy54Nlv7D2cyrk3Lhbjz4w3PbIrkxJnoTJYvJM7HDfA==
+"@vue/runtime-core@^3.2.22":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.26.tgz#5c59cc440ed7a39b6dbd4c02e2d21c8d1988f0de"
+  integrity sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==
   dependencies:
-    "@vue/reactivity" "3.0.2"
-    "@vue/shared" "3.0.2"
+    "@vue/reactivity" "3.2.26"
+    "@vue/shared" "3.2.26"
 
-"@vue/shared@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.2.tgz#419bd85a2ebdbd4f42963e98c5a1b103452176d9"
-  integrity sha512-Zx869zlNoujFOclKIoYmkh8ES2RcS/+Jn546yOiPyZ+3+Ejivnr+fb8l+DdXUEFjo+iVDNR3KyLzg03aBFfZ4Q==
+"@vue/shared@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.26.tgz#7acd1621783571b9a82eca1f041b4a0a983481d9"
+  integrity sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==
 
 "@vuepress/core@1.7.1":
   version "1.7.1"


### PR DESCRIPTION
Muban has received non-breaking updates that are part of the 1.0.0 alpha 28 release. An overview of the updates can be found in the changelog https://github.com/mubanjs/muban/blob/release/alpha-28/CHANGELOG.md#100-alpha28---2021-12-09