### PR TITLE
Fix typo in charset

### DIFF
--- a/scripts/devserver/index.html
+++ b/scripts/devserver/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charSet="utf-8">
+  <meta charset="utf-8">
   <title>Muban</title>
 
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">


### PR DESCRIPTION
The word `charset` contained a capital `s`