### PR TITLE
Remove `maximum-scale=1` from viewport meta-tag

### DIFF
--- a/scripts/devserver/index.html
+++ b/scripts/devserver/index.html
@@ -5,7 +5,7 @@
   <title>Muban</title>
 
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="app-script" content="{{publicPath}}/static/js/main.js" />
 
   {{csp}}


### PR DESCRIPTION
Removing the maximum scale improve accessibility by allowing users to zoom the content on a page.