### PR TITLE
Fix/disable formatting of load script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,8 @@ max_line_length = 100
 quote_type = single
 trim_trailing_whitespace = true
 
+# IntelliJ specific settings
+ij_formatter_tags_enabled = true
+
 [*.{md,markdown}]
 trim_trailing_whitespace = false

--- a/src/pages/public/index.html
+++ b/src/pages/public/index.html
@@ -10,13 +10,16 @@
 
   <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
 
-  <link rel="stylesheet" href="{{publicPath}}static/css/main.css"/>
-</head>
-<body>
-  <div id="app">
-    {{content}}
-  </div>
+    <link rel="stylesheet" href="{{publicPath}}static/css/main.css" />
+  </head>
+  <body>
+    <div id="app">
+      {{content}}
+    </div>
 
-  <script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
-</body>
+    <!-- @formatter:off -->
+    <!-- prettier-ignore -->
+    <script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
+    <!-- @formatter:on -->
+  </body>
 </html>


### PR DESCRIPTION
Disables formatting of the load script in the index file. Preventing that the load script hash changes due to formatting.

Currently supports:
- Disabling prettier
- Disabling IntelliJ formatting[1]

Not able to support vscode as there is [no option (yet)](https://github.com/microsoft/vscode/issues/139617) for disabling formatting for their default formatting engine (beautifyjs).


[1] Disabling IntelliJ formatting works from version 2021.2 and onwards ([source](https://youtrack.jetbrains.com/issue/IDEA-247815))